### PR TITLE
Fixes an issue where writers error would be read, not the reader

### DIFF
--- a/Sources/NextLevelSessionExporter.swift
+++ b/Sources/NextLevelSessionExporter.swift
@@ -562,7 +562,7 @@ extension NextLevelSessionExporter {
             }
             self.complete()
         } else if self._reader?.status == .failed {
-            if let error = self._writer?.error {
+            if let error = self._reader?.error {
                 debugPrint("NextLevelSessionExporter, reading failed, \(error)")
             }
             self._writer?.cancelWriting()


### PR DESCRIPTION
When debugging I noticed an error wouldn't be printed and noticed after the reader failed, it was looking for the writers error which doesn't make sense