### PR TITLE
Fix CVPixelBufferPoolCreatePixelBuffer result comparison crash

### DIFF
--- a/Sources/NextLevelSessionExporter.swift
+++ b/Sources/NextLevelSessionExporter.swift
@@ -451,8 +451,7 @@ extension NextLevelSessionExporter {
                     
                     var toRenderBuffer: CVPixelBuffer? = nil
                     let result = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pixelBufferPool, &toRenderBuffer)
-                    switch result {
-                    case kCVReturnSuccess:
+                    if result == kCVReturnSuccess {
                         if let toBuffer = toRenderBuffer {
                             self._renderHandler?(pixelBuffer, self._lastSamplePresentationTime, toBuffer)
                             if pixelBufferAdaptor.append(toBuffer, withPresentationTime:self._lastSamplePresentationTime) == false {
@@ -460,11 +459,6 @@ extension NextLevelSessionExporter {
                             }
                             handled = true
                         }
-                        break
-                    default:
-//                        debugPrint("result, \(result)")
-                        error = true
-                        break
                     }
                 }
             }


### PR DESCRIPTION
Hello. 

I fixed the issue I found with the `NextLevelSessionExporter` when building the framework with Xcode 12. 

Using `switch` with it's `default` case with `let result = CVPixelBufferPoolCreatePixelBuffer` causing this exception when running app and using the exporter

`** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: '*** -[AVAssetWriterInput appendSampleBuffer:] Cannot append sample buffer: Must start a session (using -[AVAssetWriter startSessionAtSourceTime:) first'`

I also changed `switch result` to `if result == kCVReturnSuccess` since we have nothing left to execute in `default` case. 