### PR TITLE
Fix scaling

### DIFF
--- a/Sources/NextLevelSessionExporter.swift
+++ b/Sources/NextLevelSessionExporter.swift
@@ -529,22 +529,6 @@ extension NextLevelSessionExporter {
                 }
                 videoComposition.renderSize = naturalSize
                 
-                // center the video
-                
-                var ratio: CGFloat = 0
-                let xRatio: CGFloat = targetSize.width / naturalSize.width
-                let yRatio: CGFloat = targetSize.height / naturalSize.height
-                ratio = min(xRatio, yRatio)
-                
-                let postWidth = naturalSize.width * ratio
-                let postHeight = naturalSize.height * ratio
-                let transX = (targetSize.width - postWidth) * 0.5
-                let transY = (targetSize.height - postHeight) * 0.5
-                
-                var matrix = CGAffineTransform(translationX: (transX / xRatio), y: (transY / yRatio))
-                matrix = matrix.scaledBy(x: (ratio / xRatio), y: (ratio / yRatio))
-                transform = transform.concatenating(matrix)
-                
                 // make the composition
                 
                 let compositionInstruction = AVMutableVideoCompositionInstruction()


### PR DESCRIPTION
See #33 for more context. Removing this centering logic fixes the issue and makes the exporter rely on the `AVVideoScalingModeKey`. 

I might be lacking some context and the proposed solution might break some scenarios that I am not aware of. I am open to any feedback ;)