### PR TITLE
Buffers in pool may not always point at the video compositors output

### DIFF
--- a/Sources/NextLevelSessionExporter.swift
+++ b/Sources/NextLevelSessionExporter.swift
@@ -453,11 +453,21 @@ extension NextLevelSessionExporter {
                     let result = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pixelBufferPool, &toRenderBuffer)
                     if result == kCVReturnSuccess {
                         if let toBuffer = toRenderBuffer {
-                            self._renderHandler?(pixelBuffer, self._lastSamplePresentationTime, toBuffer)
-                            if pixelBufferAdaptor.append(toBuffer, withPresentationTime:self._lastSamplePresentationTime) == false {
-                                error = true
+                            // if _renderHandler is nil, then we can save time by just passing pixelBuffer directly to pixelBufferAdaptor.append
+                            if (self._renderHandler == nil) {
+                                if pixelBufferAdaptor.append(pixelBuffer, withPresentationTime:self._lastSamplePresentationTime) == false {
+                                    error = true
+                                }
+                                handled = true
                             }
-                            handled = true
+                            // otherwise, we need to call into _renderHandler to preprocess the frames
+                            else {
+                                self._renderHandler?(pixelBuffer, self._lastSamplePresentationTime, toBuffer)
+                                if pixelBufferAdaptor.append(toBuffer, withPresentationTime:self._lastSamplePresentationTime) == false {
+                                    error = true
+                                }
+                                handled = true
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
We received a report of black frames in an applications video content once it was encoded with NextLevelSessionExporter.

Investigation revealed a similar issue as https://github.com/NextLevel/NextLevelSessionExporter/issues/38.

It appears NextLevelSessionExporter is pulling buffers from the pool that was created, and sending those buffers back to the API. The assumption a buffer pulled from that pool will contain the output of the Metal video compositor is not always correct.

This change will pass the pixelBuffer directly, or use the toBuffer if a renderHandler exists.  It resolves black frames in video content in our testing, @GrandPoohBear you may want to give it a try.