### PR TITLE
Allow configurable qos

### DIFF
--- a/Sources/NextLevelSessionExporter.swift
+++ b/Sources/NextLevelSessionExporter.swift
@@ -90,6 +90,9 @@ open class NextLevelSessionExporter: NSObject {
     /// Audio output configuration dictionary, using keys defined in `<AVFoundation/AVAudioSettings.h>`
     public var audioOutputConfiguration: [String : Any]?
     
+    /// Assign custom priority on global dispatch queue
+    public var qos: DispatchQoS.QoSClass = .default
+    
     /// Export session status state.
     public var status: AVAssetExportSession.Status {
         get {
@@ -302,7 +305,7 @@ extension NextLevelSessionExporter {
             audioSemaphore.signal()
         }
         
-        DispatchQueue.global().async {
+        DispatchQueue.global(qos: qos).async {
             audioSemaphore.wait()
             videoSemaphore.wait()
             DispatchQueue.main.async {


### PR DESCRIPTION
This is a bit ugly, but PoC test to resolve priority inversion warnings

> Thread Performance Checker: Thread running at QOS_CLASS_USER_INITIATED waiting on a lower QoS thread running at QOS_CLASS_DEFAULT. Investigate ways to avoid priority inversions
PID: 22258, TID: 26715793

This is probably more relevant in an async/await context. 

Example reproduction where callee uses qos of `.userInitiated`
```swift
Task(priority: .userInitiated) {
   try? await model.process()
}
```


```swift
    @MainActor
    class ViewModel: ObservableObject {
        @Published var proccessedVideo: URL?
        init() {}
        
       func process() async throws {
            let nl = NextLevelSessionExporter(withAsset: mixComposition)
            // nl.videoComposition = videoComposition
            // nl.videoOutputConfiguration = self.videoSettings
            // nl.audioOutputConfiguration = self.audioSettings
            // nl.outputURL = watermarkedFilepath
            
            
            try await withCheckedThrowingContinuation { continuation in
                nl.export(completionHandler:  { result in
                    switch result {
                    case .success:
                        continuation.resume()
                    case let .failure(error):
                        continuation.resume(throwing: error)
                    }
                })
            }
            
            self.proccessedVideo = watermarkedFilepath       

       }
    }
```

Confirmed warnings went away with `let nl = NextLevelSessionExporter(withAsset: mixComposition, qos: .userInitiated)`, 