### PR TITLE
Add videoTransform property for custom video transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,27 @@ exporter.export(progressHandler: { (progress) in
 })
 ```
 
+### Rotating or Transforming Video
+
+Use `videoTransform` to apply a custom affine transform to video content without building a full `AVVideoComposition` manually. The exporter applies it as the base orientation transform, then handles centering and scaling on top.
+
+This is useful when the raw encoded pixels are in an unexpected orientation — for example, a video whose `naturalSize.height > naturalSize.width` that must be delivered in landscape:
+
+```swift
+// Rotate portrait-encoded video 90° clockwise to landscape
+let isPortrait = try await videoTrack.load(.naturalSize).height > videoTrack.load(.naturalSize).width
+if isPortrait {
+    exporter.videoTransform = CGAffineTransform(rotationAngle: -.pi / 2)
+    exporter.videoOutputConfiguration = [
+        AVVideoCodecKey: AVVideoCodecType.h264,
+        AVVideoWidthKey: 1920,   // landscape width
+        AVVideoHeightKey: 1080,  // landscape height
+    ]
+}
+```
+
+Any `CGAffineTransform` works — rotations, flips, or combinations. When `videoComposition` is set directly, `videoTransform` is ignored.
+
 ## Migration Guide
 
 ### Migrating from 0.x to 1.0 (Swift 6)

--- a/Sources/NextLevelSessionExporter.swift
+++ b/Sources/NextLevelSessionExporter.swift
@@ -127,6 +127,19 @@ open class NextLevelSessionExporter: NSObject, @unchecked Sendable {
     /// Audio output configuration dictionary, using keys defined in `<AVFoundation/AVAudioSettings.h>`
     public var audioOutputConfiguration: [String : Any]?
 
+    /// An optional transform applied to video content in the auto-generated video composition.
+    /// When set, this replaces the video track's `preferredTransform` as the base transform,
+    /// allowing custom rotations, flips, or other affine transforms without building a full
+    /// `AVVideoComposition` manually. The existing centering and scaling logic still applies on top.
+    ///
+    /// Has no effect when `videoComposition` is set directly.
+    ///
+    /// Example — export a portrait-encoded video (naturalSize.height > naturalSize.width) as landscape:
+    /// ```swift
+    /// exporter.videoTransform = CGAffineTransform(rotationAngle: -.pi / 2)
+    /// ```
+    public var videoTransform: CGAffineTransform?
+
     /// Automatically detect and preserve HDR content from source video.
     /// When enabled, the exporter will detect HDR color space and transfer function
     /// from the source asset and apply appropriate 10-bit HEVC encoding settings.
@@ -772,7 +785,7 @@ extension NextLevelSessionExporter {
                 let targetSize = CGSize(width: width, height: height)
                 var naturalSize = videoTrack.naturalSize
 
-                var transform = videoTrack.preferredTransform
+                var transform = self.videoTransform ?? videoTrack.preferredTransform
 
                 let rect = CGRect(x: 0, y: 0, width: naturalSize.width, height: naturalSize.height)
                 let transformedRect = rect.applying(transform)


### PR DESCRIPTION
## Problem

  When a video is encoded with portrait pixel dimensions (naturalSize.height > naturalSize.width) and no preferredTransform rotation, there is no way to rotate the content during export without building a full
  AVVideoComposition from scratch.

## Solution

  Add a single videoTransform: CGAffineTransform? property. When set, it replaces videoTrack.preferredTransform as the base transform inside createVideoComposition(). The existing orientation detection (90°/−90°
  dimension swap) and centering/scaling logic apply on top of it unchanged, so the behaviour for all existing callers is identical.

## Why AVVideoScalingModeResizeAspectFill does not solve this

  AVVideoScalingModeResizeAspectFill controls how source content is scaled and cropped to fill the output dimensions — it does not rotate pixels. When a portrait-encoded video (e.g. 1080×1920) is exported with
  landscape output dimensions (1920×1080) and ResizeAspectFill, the composition scales the portrait content up until it fills the landscape width, then crops the top and bottom. The result is the vertical center
  slice of the portrait video stretched into a landscape frame — the content is never rotated 90°.

  Rotating a video means moving each pixel from coordinate (x, y) to (y, maxX − x). Scaling modes only change which region of the source is visible and at what size. They are fundamentally different operations, and
   no combination of scaling modes can substitute for an affine rotation transform in the layer instruction.