### PR TITLE
Don't setup audio ouput if we filtered out audio tracks

### DIFF
--- a/Sources/NextLevelSessionExporter.swift
+++ b/Sources/NextLevelSessionExporter.swift
@@ -675,6 +675,13 @@ extension NextLevelSessionExporter {
             }
         }
 
+        // If every audio track was filtered out above (e.g. asset only has APAC/spatial audio),
+        // there's nothing left for AVAssetReaderAudioMixOutput, which requires at least one track.
+        guard audioTracksToUse.count > 0 else {
+            self._audioOutput = nil
+            return
+        }
+
         self._audioOutput = AVAssetReaderAudioMixOutput(audioTracks: audioTracksToUse, audioSettings: nil)
         self._audioOutput?.alwaysCopiesSampleData = false
         self._audioOutput?.audioMix = self.audioMix


### PR DESCRIPTION
Fixes a crash where if we filter out audio tracks, such as spatial audio, and there are no audio tracks left, we would still setup the audio output.