### PR TITLE
fix: `timeRange` trimming drops the first `timeRange.start` of the selection.

### DIFF
--- a/Sources/NextLevelSessionExporter.swift
+++ b/Sources/NextLevelSessionExporter.swift
@@ -720,8 +720,16 @@ extension NextLevelSessionExporter {
                 var handled = false
                 var error = false
                 if self._videoOutput == output {
-                    // determine progress
-                    self._lastSamplePresentationTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer) - self.timeRange.start
+                    // The writer session starts at `timeRange.start`, so AVAssetWriter already
+                    // rebases source time to movie time. Sample buffers must therefore be appended
+                    // with their *original* presentation timestamp — subtracting `timeRange.start`
+                    // here as well applies the trim offset twice and silently discards every frame
+                    // before `timeRange.start` (they land at a negative movie time). This also
+                    // matches the audio path, which appends sample buffers unmodified.
+                    let samplePresentationTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+
+                    // determine progress (relative to the start of the exported range)
+                    self._lastSamplePresentationTime = samplePresentationTime - self.timeRange.start
                     let progress = self._duration == 0 ? 1 : Float(CMTimeGetSeconds(self._lastSamplePresentationTime) / self._duration)
                     self.updateProgress(progress: progress)
 
@@ -733,7 +741,7 @@ extension NextLevelSessionExporter {
                         // If no render handler, directly append the original pixel buffer
                         // This prevents black frames caused by using uninitialized pool buffers (PR #39)
                         if self._renderHandler == nil {
-                            if pixelBufferAdaptor.append(pixelBuffer, withPresentationTime: self._lastSamplePresentationTime) == false {
+                            if pixelBufferAdaptor.append(pixelBuffer, withPresentationTime: samplePresentationTime) == false {
                                 error = true
                             }
                             handled = true
@@ -744,7 +752,7 @@ extension NextLevelSessionExporter {
                             if result == kCVReturnSuccess {
                                 if let toBuffer = toRenderBuffer {
                                     self._renderHandler?(pixelBuffer, self._lastSamplePresentationTime, toBuffer)
-                                    if pixelBufferAdaptor.append(toBuffer, withPresentationTime: self._lastSamplePresentationTime) == false {
+                                    if pixelBufferAdaptor.append(toBuffer, withPresentationTime: samplePresentationTime) == false {
                                         error = true
                                     }
                                     handled = true


### PR DESCRIPTION
`startSession(atSourceTime: timeRange.start)` already makes AVAssetWriter rebase
source time to movie time, but video frames are also appended at
`PTS - timeRange.start`. That applies the offset twice, so frames before
`timeRange.start` resolve to a negative movie time and the writer discards them —
`append` still returns `true`, so nothing surfaces as an error. Audio is appended
unmodified and keeps the full range.

Trimming an 18s clip to 3s–18s gave me a 15s file with a 12s video track and a
15s audio track: playback starts ~3s into the selection, and the final frame is
frozen for the remaining 3s.

Appending with the original presentation timestamp fixes both append paths and
matches what the audio path already does. Progress reporting still uses the
range-relative time, so that behaviour is unchanged.

One thing worth knowing: this dates back to the initial commit, but it used to be
masked. `CVPixelBufferPoolCreatePixelBuffer` fails with
`kCVReturnInvalidPixelFormat` (the pool attributes ask for
`kCVPixelFormatType_32RGBA`), so `handled` stayed `false` and every frame fell
through to the plain `input.append(sampleBuffer)`, which got the timing right by
accident. #39's black-frame fix skips that allocation when there's no render
handler, which is what made the bug reachable in 1.0.1.